### PR TITLE
Sge executor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
+.DS_Store
+.nextflow*
+nextflow
+results
+*.sif
+work
+environments/.DS_Store
+
+# A place to store site specific configs
 site-conf/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,1 @@
-.DS_Store
-.nextflow*
-nextflow
-results
-*.sif
-work
-environments/.DS_Store
-
+site-conf/

--- a/conf/gothenburg.config
+++ b/conf/gothenburg.config
@@ -1,0 +1,6 @@
+gothenburg {
+  process.executor = 'sge'
+  process.queue = 'wgs.q'
+  process.penv = 'mpi'
+  process.clusterOptions = '-l excl=1'
+}

--- a/conf/gothenburg.config
+++ b/conf/gothenburg.config
@@ -1,8 +1,0 @@
-profiles {
-  gothenburg {
-    process.executor = 'sge'
-    process.queue = 'wgs.q'
-    process.penv = 'mpi'
-    process.clusterOptions = '-l excl=1'
-  }
-}

--- a/conf/gothenburg.config
+++ b/conf/gothenburg.config
@@ -1,6 +1,8 @@
-gothenburg {
-  process.executor = 'sge'
-  process.queue = 'wgs.q'
-  process.penv = 'mpi'
-  process.clusterOptions = '-l excl=1'
+profiles {
+  gothenburg {
+    process.executor = 'sge'
+    process.queue = 'wgs.q'
+    process.penv = 'mpi'
+    process.clusterOptions = '-l excl=1'
+  }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,9 @@ if ( params.illumina ){
     includeConfig 'conf/illumina.config'
 }
 
+if ( params.gothenburg ){
+   includeConfig 'conf/gothenburg.config'
+}
 
 profiles {
   conda {
@@ -66,6 +69,8 @@ profiles {
     process.executor = 'google-lifesciences'
     includeConfig 'conf/gls.config'
   }
+  sge {
+    process.executor = 'sge'
 }
 
 // COG-UK institutional config

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,6 +15,10 @@ params {
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
 
+// Load in any site-specific config files
+if ( params.siteconf ) {
+   includeConfig params.siteconf
+}
 
 if ( params.medaka || params.nanopolish ){
     includeConfig 'conf/nanopore.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -73,9 +73,6 @@ profiles {
 // COG-UK institutional config
 includeConfig 'conf/coguk.config'
 
-// Site specific config
-includeConfig 'conf/gothenburg.config'
-
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,10 +24,6 @@ if ( params.illumina ){
     includeConfig 'conf/illumina.config'
 }
 
-if ( params.gothenburg ){
-   includeConfig 'conf/gothenburg.config'
-}
-
 profiles {
   conda {
      if ( params.medaka || params.nanopolish ) {
@@ -71,10 +67,14 @@ profiles {
   }
   sge {
     process.executor = 'sge'
+  }
 }
 
 // COG-UK institutional config
 includeConfig 'conf/coguk.config'
+
+// Site specific config
+includeConfig 'conf/gothenburg.config'
 
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']


### PR DESCRIPTION
### The purpose of the code changes are as follows:
This adds a parameter for specifying a local site config. Using `--siteconf /path/to/conf` and `-profile sitename` one can specify site specific configurations such as executors. 
This could then also be a way for site to have even more involved settings regarding what outputs to produce or whatever.

I've also added 'site-conf' to .gitignore as a place to put such site-specific config files.

One could have used `nextflow run -c /path/to/conf`but it didn't feel as nice to use.

I would also be nice to have a exemple.config in site-conf as a way to show new sites a easy way to set up the pipeline for their local infrastructure.