### PR TITLE
Pangolin typing with medaka

### DIFF
--- a/workflows/articNcovNanopore.nf
+++ b/workflows/articNcovNanopore.nf
@@ -125,7 +125,8 @@ workflow sequenceAnalysisMedaka {
      collateSamples(qc.pass.map{ it[0] }
                            .join(articMinIONMedaka.out.consensus_fasta, by: 0)
                            .join(articRemoveUnmappedReads.out))
-                                              
+
+     pangolinTyping(articMinIONMedaka.out.consensus_fasta)
 
      if (params.outCram) {
         bamToCram(articMinIONMedaka.out.ptrim.map{ it[0] } 


### PR DESCRIPTION
This PR allows pangolin types to be assigned when running analysis of nanopore data with the medaka workflow