### PR TITLE
downgraded nextclade

### DIFF
--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - picard=2.25.2
   - fastqc=0.11.9
   - multiqc=1.11
-  - nextclade=1.10.2
+  - nextclade=1.8.1
   - pip:
       - pandas >= 1.1
       - scikit-learn >= 0.23.1

--- a/environments/nanopore/environment.yml
+++ b/environments/nanopore/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - usher=0.2.0
   - snakemake-minimal=5.13
   - minimap2=2.17
-  - nextclade=1.10.2
+  - nextclade=1.8.1
   - muscle=3.8
   - pip:
       - pandas == 1.0.1


### PR DESCRIPTION
From Nextclade v1.10.0 then the flag `--input-dataset` has to be used (which we are not using). I suggest we upgrade Nextclade first when gms-artic is compatible with the new version of Nextclade.