### PR TITLE
Use conda to solve environment instead of mamba

### DIFF
--- a/.github/workflows/build_dockerfile.yml
+++ b/.github/workflows/build_dockerfile.yml
@@ -5,7 +5,7 @@ on:
    - cron: '0 0 * * *'
  push:
     branches:
-      - fix_mamba 
+      - fix_mamba_conda 
 jobs:
   get-version:
     runs-on: ubuntu-latest

--- a/environments/illumina/Dockerfile
+++ b/environments/illumina/Dockerfile
@@ -5,9 +5,7 @@ LABEL authors="Matt Bull" \
 COPY environments/extras.yml /extras.yml
 COPY environments/illumina/environment.yml /environment.yml
 RUN /opt/conda/bin/conda update conda && \
-/opt/conda/bin/conda install mamba -c conda-forge && \
-/opt/conda/bin/conda update mamba -c conda-forge && \
-/opt/conda/bin/mamba env create -f /environment.yml
+/opt/conda/bin/conda env create -f /environment.yml
 
 FROM debian:buster-slim
 RUN apt-get update && \


### PR DESCRIPTION
There are many conflicts with the latest version installation of mamba using conda and this GHaction failed. https://github.com/genomic-medicine-sweden/gms-artic/actions/runs/2412168987

### The purpose of the code changes are as follows:
I used conda to build the container instead of mamba.

### This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
