### PR TITLE
Specify pangolin version via variable at docker build

### DIFF
--- a/.github/workflows/build_dockerfile.yml
+++ b/.github/workflows/build_dockerfile.yml
@@ -78,7 +78,7 @@ jobs:
          #Build docker for nanopore
          docker build --no-cache -f environments/nanopore/Dockerfile -t genomicmedicinesweden/gms-artic-nanopore:latest -t genomicmedicinesweden/gms-artic-nanopore:${{ steps.date.outputs.date }}-p-${REPO_VER}-d-${pangolin_data_VER}-c-${constellations_VER}-s-${scorpio_VER} .
          #Build docker for pangolin-check for specific requirements
-         docker build --no-cache -f environments/nanopore/pangolin/Dockerfile -t genomicmedicinesweden/gms-artic-pangolin:latest -t genomicmedicinesweden/gms-artic-pangolin:${{ steps.date.outputs.date }}-p-${REPO_VER}-d-${pangolin_data_VER}-c-${constellations_VER}-s-${scorpio_VER} .
+         docker build --no-cache -f environments/nanopore/pangolin/Dockerfile -t genomicmedicinesweden/gms-artic-pangolin:latest -t genomicmedicinesweden/gms-artic-pangolin:${{ steps.date.outputs.date }}-p-${REPO_VER}-d-${pangolin_data_VER}-c-${constellations_VER}-s-${scorpio_VER} --build-arg PANGOLIN_VER=v${REPO_VER} .
 
      - name: Push Docker image to DockerHub
        shell: bash

--- a/environments/nanopore/pangolin/Dockerfile
+++ b/environments/nanopore/pangolin/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:xenial
 
+ARG PANGOLIN_VER
+
 # install needed software for conda install; cleanup apt garbage
 RUN apt-get update && apt-get install -y \
  wget \
@@ -11,9 +13,9 @@ RUN apt-get update && apt-get install -y \
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
  bash ./Miniconda3-latest-Linux-x86_64.sh -p /miniconda -b  && \
  rm Miniconda3-latest-Linux-x86_64.sh && \
- wget "https://github.com/cov-lineages/pangolin/archive/refs/tags/v3.1.14.tar.gz" && \
- tar -xf v3.1.14.tar.gz && \
- rm v3.1.14.tar.gz && \
+ wget "https://github.com/cov-lineages/pangolin/archive/refs/tags/${PANGOLIN_VER}.tar.gz" && \
+ tar -xf "${PANGOLIN_VER}.tar.gz" && \
+ rm "${PANGOLIN_VER}.tar.gz" && \
  mv -v pangolin-* pangolin
 
 # set the environment
@@ -38,6 +40,6 @@ RUN cd pangolin && \
  pip install . && \
  conda clean -a -y && \
  mkdir /data && \
- pangolin -v && pangolin -pv && pangolin -dv
+ pangolin --all-versions
 
 WORKDIR /data


### PR DESCRIPTION
The pangolin container is hardcoded to download v3.1.14. This leads to different pangolin versions being reported in the pipeline output (since the nanopore container has the latest version). The pangolin containers on DockerHub tagged with the later pangolin versions (eg. p-4.1.1) currently contain v3.1.14.

### The purpose of the code changes are as follows:
* Ensures the latest pangolin version is downloaded at `docker build` of the pangolin container
* Ensures that the pangolin version is consistent throughout the pipeline and in the container tag
* Minor tweaks to ensure the automatic builds are compatible with pangolin v4.x.x

### Standard test procedure
- [x] The self-test mentioned in the README finished successfully
- [x] Produced files contain expected values
- [ ] The code has been reviewed by @octocat

### This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
