### PR TITLE
add java mem options

### DIFF
--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -92,7 +92,7 @@ process statsInsert {
     mkdir ./tmp
     if [[ \$( samtools view -F 12 ${bam} | cut -f1 | sort -T ./tmp | uniq -c | awk '\$1 > 1 { count++ } END { print count }' ) > 0 ]]
     then
-       picard CollectInsertSizeMetrics I=${bam} O=${sampleName}_insert_size.metrics.txt \
+       picard ${params.picardJavaSettings} CollectInsertSizeMetrics I=${bam} O=${sampleName}_insert_size.metrics.txt \
        H=${sampleName}_insert_size.distribution.pdf \
        TMP_DIR=${params.tmpdir}
     else
@@ -114,7 +114,7 @@ process statsAlignment {
     path "${sampleName}_alignment.metrics.txt"
 
     """
-    picard CollectAlignmentSummaryMetrics R=${ref} I=${bam} O=${sampleName}_alignment.metrics.txt
+    picard ${params.picardJavaSettings} CollectAlignmentSummaryMetrics R=${ref} I=${bam} O=${sampleName}_alignment.metrics.txt
     """
 }
 


### PR DESCRIPTION
### The purpose of the code changes are as follows:
* Added java memory options for all Picard commands. Can be set individually if needed in the nextflow config. 

### Standard test procedure
- [ ] The self-test mentioned in the README finished successfully
- [ ] Produced files contain expected values
- [ ] The code has been reviewed by @octocat

### This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
