### PR TITLE
Fix pangolin-assignment

### DIFF
--- a/environments/pangolin/Dockerfile
+++ b/environments/pangolin/Dockerfile
@@ -57,6 +57,8 @@ RUN sed -i "s|usher.*|usher=${USHER_VER}|" /pangolin/environment.yml && \
     sed -i "s|scorpio.git|scorpio.git@${SCORPIO_VER}|" /pangolin/environment.yml && \
     sed -i "s|pangolin-data.git|pangolin-data.git@${PANGOLIN_DATA_VER}|" /pangolin/environment.yml && \
     sed -i "s|constellations.git|constellations.git@${CONSTELLATIONS_VER}|" /pangolin/environment.yml && \
+    sed -i "12 a\  - pulp=2.7.0" /pangolin/environment.yml && \
+    sed -i '/.*defaults/d' /pangolin/environment.yml && \
     micromamba create -n pangolin -y -f /pangolin/environment.yml && \
     micromamba clean -a -y -f
 

--- a/environments/pangolin/environment_pangolin.yml
+++ b/environments/pangolin/environment_pangolin.yml
@@ -18,4 +18,5 @@ dependencies:
     - git+https://github.com/cov-lineages/scorpio.git
     - git+https://github.com/cov-lineages/constellations.git
     - git+https://github.com/cov-lineages/pangolin-data.git
+    - git+https://github.com/cov-lineages/pangolin-assignment.git
     


### PR DESCRIPTION
### The purpose of the code changes are as follows:
* The pangolin-assignment is failing when building the docker container. I have fixed that

### Standard test procedure
- [ ] The self-test mentioned in the README finished successfully
- [ ] Produced files contain expected values
- [ ] The code has been reviewed by @octocat

### This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
